### PR TITLE
Filter out empty tags when creating or editing accounts

### DIFF
--- a/entrypoints/sidepanel/components/TagsInput.tsx
+++ b/entrypoints/sidepanel/components/TagsInput.tsx
@@ -11,8 +11,12 @@ export default function TagsInput({ allKnownTags, initialTags }: TagsInputProps)
     const [hiddenValue, setHiddenValue] = useState<string>(JSON.stringify(initialTags));
 
     const handleChange = useCallback((newTags: string[]) => {
-        setTags(newTags);
-        setHiddenValue(JSON.stringify(newTags));
+        // Filter out empty tags and trim whitespace
+        const filteredTags = newTags
+            .map(tag => tag.trim())
+            .filter(tag => tag.length > 0);
+        setTags(filteredTags);
+        setHiddenValue(JSON.stringify(filteredTags));
     }, []);
 
     return (


### PR DESCRIPTION
## Summary
- Filters out empty/whitespace-only tags in the TagsInput component
- Prevents empty tags from being saved when users accidentally add blank entries
- Applies to both account creation and editing flows

## Test plan
- [x] Verified empty tags are filtered out when creating a new account
- [x] Verified empty tags are filtered out when editing an existing account
- [x] Confirmed valid tags still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)